### PR TITLE
Fix actions probabilities negative values issue

### DIFF
--- a/agent/asyncrl/policy_output.py
+++ b/agent/asyncrl/policy_output.py
@@ -22,7 +22,10 @@ def _sample_discrete_actions(batch_probs):
     # Subtract a tiny value from probabilities in order to avoid
     # "ValueError: sum(pvals[:-1]) > 1.0" in numpy.multinomial
     batch_probs = batch_probs - np.finfo(np.float32).epsneg
-
+    # Apply absolute function to keep values positive
+    # "ValueError: pvals < 0, pvals > 1 or pvals contains NaNs" in numpy.multinomial
+    batch_probs = np.absolute(batch_probs)
+    
     for i in range(batch_probs.shape[0]):
         histogram = np.random.multinomial(1, batch_probs[i])
         action_indices.append(int(np.nonzero(histogram)[0]))


### PR DESCRIPTION
I had some errors while running the run_RL.py script (I opened an issue #17), but I think with this additive line, this error should not show up again. 